### PR TITLE
fix: :bug: Le CSS doit être importé à part

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
 import * as components from './components/index.js'
-import './main.css'
-import './assets/fonts-dsfr.css'
 import VIcon from './icons.js'
 
 export default {


### PR DESCRIPTION
Le CSS doit être importé à part comme décrit dans la
[documentation](https://vue-dsfr.netlify.app/?path=/story/docs-guide-d-utilisation--page#comment-d%C3%A9buter).
