### PR TITLE
feat: :sparkles: Emét l'évenement 'select-tab' lors du clic sur TabItem

### DIFF
--- a/src/components/DsfrTabs/DsfrTabs.vue
+++ b/src/components/DsfrTabs/DsfrTabs.vue
@@ -62,6 +62,8 @@ export default {
     },
   },
 
+  emits: ['select-tab'],
+
   data () {
     return {
       getRandomId,
@@ -86,6 +88,7 @@ export default {
     async selectIndex (idx) {
       this.asc = idx > this.selectedIndex
       this.selectedIndex = idx
+      this.$emit('select-tab', idx)
     },
   },
 }


### PR DESCRIPTION
Pour pouvoir gérer de façon personnalisée le contenu des onglets
